### PR TITLE
Update ProgressWheel.java

### DIFF
--- a/src/com/todddavies/components/progressbar/ProgressWheel.java
+++ b/src/com/todddavies/components/progressbar/ProgressWheel.java
@@ -275,6 +275,18 @@ public class ProgressWheel extends View {
     }
 
     /**
+    *   Check if the wheel is currently spinning
+    */
+    
+    public boolean isSpinning() {
+        if(isSpinning){
+            return true;
+        } else {
+            return false;
+        }
+    }
+    
+    /**
      * Reset the count (in increment mode)
      */
     public void resetCount() {


### PR DESCRIPTION
Added a public boolean to test if the wheel is currently spinning. Use with .isSpinning()

Added because I found that with multiple calls to .spin() the speed of the spinning on the wheel would increase until it crashes. 

_Note_ I imagine this could be included in the .spin() method(? im not sure thats the right term) but I did not want to accidentally break functionality. I am still new to this.
