### PR TITLE
Update build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.6.+'
+        classpath 'com.android.tools.build:gradle:0.8.+'
     }
 }
 


### PR DESCRIPTION
0.6 gradle plugin is no longer supported with Android Studio latest releases, so one will not be able import the project from Github to Android Studio if it uses plugin 0.6. so i made  it 0.8+
