### PR TITLE
Fix issue#44 Set attribute values programmatically won't change the visual of the progress wheel.

### DIFF
--- a/src/com/todddavies/components/progressbar/ProgressWheel.java
+++ b/src/com/todddavies/components/progressbar/ProgressWheel.java
@@ -410,6 +410,10 @@ public class ProgressWheel extends View {
 
     public void setBarWidth(int barWidth) {
         this.barWidth = barWidth;
+        
+        if ( this.barPaint != null ) {
+        	this.barPaint.setStrokeWidth( this.barWidth );
+        }
     }
 
     public int getTextSize() {
@@ -418,6 +422,10 @@ public class ProgressWheel extends View {
 
     public void setTextSize(int textSize) {
         this.textSize = textSize;
+        
+        if ( this.textPaint != null ) {
+        	this.textPaint.setTextSize( this.textSize );
+        }
     }
 
     public int getPaddingTop() {
@@ -458,6 +466,10 @@ public class ProgressWheel extends View {
 
     public void setBarColor(int barColor) {
         this.barColor = barColor;
+        
+        if ( this.barPaint != null ) {
+        	this.barPaint.setColor( this.barColor );
+        }
     }
 
     public int getCircleColor() {
@@ -466,6 +478,10 @@ public class ProgressWheel extends View {
 
     public void setCircleColor(int circleColor) {
         this.circleColor = circleColor;
+        
+        if ( this.circlePaint != null ) {
+        	this.circlePaint.setColor( this.circleColor);
+        }
     }
 
     public int getRimColor() {
@@ -474,6 +490,10 @@ public class ProgressWheel extends View {
 
     public void setRimColor(int rimColor) {
         this.rimColor = rimColor;
+        
+        if ( this.rimPaint != null ) {
+        	this.rimPaint.setColor( this.rimColor );
+        }
     }
 
 
@@ -491,6 +511,10 @@ public class ProgressWheel extends View {
 
     public void setTextColor(int textColor) {
         this.textColor = textColor;
+        
+        if ( this.textPaint != null ) {
+        	this.textPaint.setColor( this.textColor );
+        }
     }
 
     public int getSpinSpeed() {
@@ -507,6 +531,10 @@ public class ProgressWheel extends View {
 
     public void setRimWidth(int rimWidth) {
         this.rimWidth = rimWidth;
+        
+        if ( this.rimPaint != null ) {
+        	this.rimPaint.setStrokeWidth( this.rimWidth );
+        }
     }
 
     public int getDelayMillis() {
@@ -515,5 +543,29 @@ public class ProgressWheel extends View {
 
     public void setDelayMillis(int delayMillis) {
         this.delayMillis = delayMillis;
+    }
+    
+    public int getContourColor() {
+    	return contourColor;
+    }
+    
+    public void setContourColor(int contourColor) {
+    	this.contourColor = contourColor;
+    	
+    	if ( contourPaint != null ) {
+    		this.contourPaint.setColor( this.contourColor );
+    	}
+    }
+    
+    public float getContourSize() {
+    	return this.contourSize;
+    }
+    
+    public void setContourSize(float contourSize) {
+    	this.contourSize = contourSize;
+    	
+    	if ( contourPaint != null ) {
+    		this.contourPaint.setStrokeWidth( this.contourSize );
+    	}
     }
 }


### PR DESCRIPTION
Overview
Whenever attribute values have been changed programatically, the visual of the progress wheel isn't updated with the new attribute values. This is due to the actual visual objects (i.e. barPaint, etc...) aren't being set with the new attribute values. 
